### PR TITLE
Release 0.1.7+4.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeromq-src"
-version = "0.1.6-preview.1+4.3.2"
+version = "0.1.7+4.3.2"
 authors = ["jean-airoldie <maxence.caron@protonmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@ impl Build {
         // On windows we need to rename the static compiled lib
         // since its name is unpredictable.
         if target.contains("msvc") {
-            if let Err(_) = rename_libzmq_in_dir(&lib_dir, "zmq.lib") {
+            if rename_libzmq_in_dir(&lib_dir, "zmq.lib").is_err() {
                 panic!("unable to find compiled `libzmq` lib");
             }
         }


### PR DESCRIPTION
Now using libzmq version 4.3.2

This closes #10.