### PR TITLE
Cleanup previous merge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeromq-src"
-version = "0.1.10+4.3.2"
+version = "0.2.0+4.3.4"
 authors = ["jean-airoldie <maxence.caron@protonmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -16,3 +16,4 @@ members = ["testcrate"]
 
 [dependencies]
 cc = { version = "1", features = ["parallel"] }
+dircpy = "0.3.8"

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -4,7 +4,6 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=PROFILE");
 
-    let wants_debug = env::var("PROFILE").unwrap() == "debug";
     let maybe_libsodium = if cfg!(feature = "libsodium") {
         let lib_dir = env::var("DEP_SODIUM_LIB")
             .expect("build metadata `DEP_SODIUM_LIB` required");
@@ -17,7 +16,6 @@ fn main() {
     };
 
     zeromq_src::Build::new()
-        .build_debug(wants_debug)
         .with_libsodium(maybe_libsodium)
         .build();
 }


### PR DESCRIPTION
* Make linking against libsodium mandatory to enable curve.
* Remove unused structures.
* Update tests to reflect changes.

@Jasper-Bekkers 

I'm thinking of merging this then release 0.2. Then I'll PR libzmq.

Btw thanks a lot for your work, I know for a fact that making c & c++ builds work properly is nightmarish.