### PR TITLE
Define `strlcpy()` to be available on Android targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,6 +377,10 @@ impl Build {
 
             build.define("HAVE_STRNLEN", "1");
             build.define("ZMQ_HAVE_UIO", "1");
+
+            if target.contains("android") {
+                build.define("ZMQ_HAVE_STRLCPY", "1");
+            }
         } else if target.contains("apple") {
             create_platform_hpp_shim(&mut build);
             build.define("ZMQ_IOTHREAD_POLLER_USE_KQUEUE", "1");


### PR DESCRIPTION
    zeromq-src-rs-0f53d1812b0afc70/ad5010b/vendor/src/compat.hpp:45:1: error: static declaration of 'strlcpy' follows non-static declaration
    strlcpy (char *dest_, const char *src_, const size_t dest_size_)
    ^
    Android/Sdk/ndk/25.0.8151533/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/string.h:146:8: note: previous declaration is here
    size_t strlcpy(char* __dst, const char* __src, size_t __n);
           ^

This definition has been traced back to at least NDK 19.2.
