### PR TITLE
Add ZMQ_HAVE_STRLCPY for musl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,6 +381,10 @@ impl Build {
             if target.contains("android") {
                 build.define("ZMQ_HAVE_STRLCPY", "1");
             }
+
+            if target.contains("musl") {
+                build.define("ZMQ_HAVE_STRLCPY", "1");
+            }
         } else if target.contains("apple") {
             create_platform_hpp_shim(&mut build);
             build.define("ZMQ_IOTHREAD_POLLER_USE_KQUEUE", "1");


### PR DESCRIPTION
AFAIK (not a c++ programmer) musl's libc always has `strlcpy` defined, unlike glibc. It may be possible to have this conditional outside of the `target.contains("linux")` section, but I don't have a good way to test that. I'm not sure why `libzmq`'s `ZMQ_HAVE_STRLCPY` configure detection code doesn't work here, but I know this change fixes the issue.

Fixes #21.