### PR TITLE
Automatically run testcrate in root tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ members = ["testcrate"]
 [dependencies]
 cc = { version = "1", features = ["parallel"] }
 dircpy = "0.3.8"
+
+[dev-dependencies]
+testcrate = { path = "./testcrate", features = ["libsodium"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,3 +428,22 @@ impl Build {
         println!("cargo:out={}", out_dir.display());
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn version_works() {
+        let version = testcrate::version();
+        println!("{:?}", version);
+        assert_eq!(version, (4, 3, 4));
+    }
+
+    #[test]
+    fn sodium_version_works() {
+        let version = testcrate::sodium_version();
+        println!("{:?}", version.to_str().unwrap());
+        assert!(version.to_str().unwrap().starts_with("1.0"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,8 +431,6 @@ impl Build {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
     #[test]
     fn version_works() {
         let version = testcrate::version();

--- a/testcrate/src/lib.rs
+++ b/testcrate/src/lib.rs
@@ -29,23 +29,3 @@ pub fn version() -> (i32, i32, i32) {
 pub fn sodium_version() -> &'static CStr {
     unsafe { CStr::from_ptr(sodium_version_string()) }
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn version_works() {
-        let version = version();
-        println!("{:?}", version);
-        assert_eq!(version, (4, 3, 4));
-    }
-
-    #[test]
-    #[cfg(feature = "libsodium")]
-    fn sodium_version_works() {
-        let version = sodium_version();
-        println!("{:?}", version.to_str().unwrap());
-        assert!(version.to_str().unwrap().starts_with("1.0"));
-    }
-}


### PR DESCRIPTION
It seems that if a git submodule is not properly initialize on the machine that will publish the crate, cargo won't warn or detect it, as described in this issue https://github.com/rust-lang/cargo/issues/8635. This is hard to detect because the CI is setup to properly `git clone --recursive` and therefore should not detect this issue.

To reduce the likelyhood of https://github.com/jean-airoldie/zeromq-src-rs/issues/23 from happening again in the future, the `testcrate` was added as a dev-dedependecy to the root crate and the tests were moved to the root crate so that if `cargo test` is ran (even without the --workspace flag), the tests won't compile and the error should be detected.