### PR TITLE
Enable ZMQ_HAVE_STRLCPY for GLIBC >= 2.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ members = ["testcrate"]
 [dependencies]
 cc = { version = "1", features = ["parallel"] }
 dircpy = "0.3.8"
-libc = "0.2"
 
 [dev-dependencies]
 testcrate = { path = "./testcrate", features = ["libsodium"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = ["testcrate"]
 [dependencies]
 cc = { version = "1", features = ["parallel"] }
 dircpy = "0.3.8"
+libc = "0.2"
 
 [dev-dependencies]
 testcrate = { path = "./testcrate", features = ["libsodium"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,7 @@ impl Build {
             println!("cargo:rustc-link-search={:?}", libsodium.lib_dir());
 
             if target.contains("msvc") {
-                std::fs::copy(
+                fs::copy(
                     libsodium
                         .include_dir()
                         .join("../../../builds/msvc/version.h"),
@@ -341,7 +341,7 @@ impl Build {
             // https://cmake.org/cmake/help/latest/command/configure_file.html
             // TODO: Replace `#cmakedefine` with the appropriate `#define`
             // let _platform_file =
-            //     std::fs::read_to_string(path.join("builds/cmake/platform.hpp.in"))
+            //     fs::read_to_string(path.join("builds/cmake/platform.hpp.in"))
             //         .unwrap();
 
             let out_includes = PathBuf::from(std::env::var("OUT_DIR").unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ mod glibc {
         // https://rust-lang.github.io/rfcs/1721-crt-static.html
         let target = env::var("CARGO_CFG_TARGET_FEATURE").unwrap();
 
-        if target.contains("ctr-static") {
+        if target.contains("crt-static") {
             // We link statically against glibc, therefore host and target libc
             // version will match.
             Version::from_libc().has_strlcpy()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,12 +61,12 @@ mod glibc {
     use std::{cmp, ffi::CStr, num, str};
 
     #[derive(Debug, Eq, PartialEq, Copy, Clone)]
-    pub(crate) struct GlibcVersion {
+    pub(crate) struct Version {
         major: u16,
         minor: u16,
     }
 
-    impl Ord for GlibcVersion {
+    impl Ord for Version {
         fn cmp(&self, other: &Self) -> cmp::Ordering {
             match self.major.cmp(&other.major) {
                 cmp::Ordering::Greater => return cmp::Ordering::Greater,
@@ -77,13 +77,13 @@ mod glibc {
         }
     }
 
-    impl PartialOrd for GlibcVersion {
+    impl PartialOrd for Version {
         fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
             Some(self.cmp(other))
         }
     }
 
-    impl GlibcVersion {
+    impl Version {
         #[inline]
         const fn new(major: u16, minor: u16) -> Self {
             Self { major, minor }
@@ -109,7 +109,7 @@ mod glibc {
             //     from OpenBSD, and are expected to be added to a future POSIX version.
             //
             // https://sourceware.org/pipermail/libc-alpha/2023-July/150524.html
-            self >= GlibcVersion::new(2, 38)
+            self >= Version::new(2, 38)
         }
     }
 
@@ -122,7 +122,7 @@ mod glibc {
         }
     }
 
-    impl str::FromStr for GlibcVersion {
+    impl str::FromStr for Version {
         type Err = BadVersion;
         fn from_str(s: &str) -> Result<Self, BadVersion> {
             let mut iter = s.split('.');
@@ -475,7 +475,7 @@ impl Build {
 
         // https://github.com/jean-airoldie/zeromq-src-rs/issues/28
         #[cfg(target_env = "gnu")]
-        if glibc::GlibcVersion::from_libc().has_strlcpy() {
+        if glibc::Version::from_libc().has_strlcpy() {
             build.define("ZMQ_HAVE_STRLCPY", "1");
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ mod glibc {
         build.cargo_metadata(false);
         build.warnings_into_errors(true);
 
-        build.include("src/strlcpy.c");
+        build.file("src/strlcpy.c");
         build.try_compile("has_strlcpy").is_ok()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,10 @@ where
 mod glibc {
     use std::path::Path;
 
-    // Attempt to compile a c program that links to strlcpy from the std
-    // library to determine whether glibc packages it.
+    // Attempt to compile a c program that refers to strlcpy from the std
+    // library to determine whether glibc packages it. If the function
+    // declaration cannot be found, a warning, escallated into an error,
+    // is emmited.
     pub(crate) fn has_strlcpy() -> bool {
         let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/strlcpy.c");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,15 +58,19 @@ where
 
 #[cfg(target_env = "gnu")]
 mod glibc {
+    use std::path::Path;
+
     // Attempt to compile a c program that links to strlcpy from the std
     // library to determine whether glibc packages it.
     pub(crate) fn has_strlcpy() -> bool {
-        let mut build = cc::Build::new();
-        build.cargo_metadata(false);
-        build.warnings_into_errors(true);
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/strlcpy.c");
 
-        build.file("src/strlcpy.c");
-        build.try_compile("has_strlcpy").is_ok()
+        cc::Build::new()
+            .cargo_metadata(false)
+            .warnings_into_errors(true)
+            .file(path)
+            .try_compile("has_strlcpy")
+            .is_ok()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,10 @@ where
 
 #[cfg(target_env = "gnu")]
 mod glibc {
-    use std::{path::{Path, PathBuf}, env};
+    use std::{
+        env,
+        path::{Path, PathBuf},
+    };
 
     // Attempt to compile a c program that links to strlcpy from the std
     // library to determine whether glibc packages it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,9 @@ mod glibc {
     // library to determine whether glibc packages it.
     pub(crate) fn has_strlcpy() -> bool {
         let mut build = cc::Build::new();
+        build.cargo_metadata(false);
+        build.warnings_into_errors(true);
+
         build.include("src/strlcpy.c");
         build.try_compile("has_strlcpy").is_ok()
     }

--- a/src/strlcpy.c
+++ b/src/strlcpy.c
@@ -1,0 +1,6 @@
+#include <string.h>
+
+int main() {
+    char *src, buf[1];
+    (void)strlcpy(buf, src, 0);
+}

--- a/src/strlcpy.c
+++ b/src/strlcpy.c
@@ -1,6 +1,7 @@
 #include <string.h>
 
 int main() {
-    char *src, buf[1];
-    (void)strlcpy(buf, src, 0);
+    char buf[1];
+    (void)strlcpy(buf, "a", 1);
+    return 0;
 }


### PR DESCRIPTION
Fixes https://github.com/jean-airoldie/zeromq-src-rs/issues/28

@MarijnS95 This approach checks `glibc` version. This results in better compilation speed than the CMAKE `CheckCXXSymbolExists` approach which involves compiling multiple times. Please tell me if it fixes your issue.

This should work for any platform that uses `glibc`.

## Open questions:
* The cargo doc specify `target_env` == "" as being valid for historical reasons so I wonder if some GNU target might have that field empty.
https://doc.rust-lang.org/reference/conditional-compilation.html#target_env.