### PR TITLE
Use `CARGO_CFG_TARGET_ENV` to determine if the target env ABI is `gnu`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,6 @@ where
     Err(())
 }
 
-#[cfg(target_env = "gnu")]
 mod glibc {
     use std::{
         env,
@@ -426,8 +425,10 @@ impl Build {
         }
 
         // https://github.com/jean-airoldie/zeromq-src-rs/issues/28
-        #[cfg(target_env = "gnu")]
-        if !has_strlcpy && glibc::has_strlcpy() {
+        if env::var("CARGO_CFG_TARGET_ENV").unwrap() == "gnu"
+            && !has_strlcpy
+            && glibc::has_strlcpy()
+        {
             has_strlcpy = true;
         }
 


### PR DESCRIPTION
Fixes #30

The unfortunately named `target_cfg` used in a `cfg()` macro / attribute is a *host* flag (as all other `cfg()`s) when a build script _using this library_ is compiled for the host.  Instead, the `ENV` of the compile _target_ should be read from an environment variable (just like `$TARGET`) when this code is being run _on the host_ to figure out what the target environment ABI is.

This causes a cross-compile via `xwin` (reported in #30) to invoke the `glibc` compile test even though windows doesn't provide `glibc`.  When cross-compiling to `x86_64-pc-windows-msvc` `target_env` will still be `"gnu"` while `CARGO_CFG_TARGET_ENV` properly represents `msvc`.

Aside from this I do think that the compile-check is valid for MSVC, the warning in that error even suggests to include `<string.h>`, but the test `.c` file already does exactly this... Perhaps the arguments set up by `xwin` and/or the `sccache` wrapper there are incompatible with how we invoke the compiler for this test?
