### PR TITLE
Test whether c++11 is supported and enable it if so

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,8 @@ mod cxx11 {
             PathBuf::from(env::var("OUT_DIR").unwrap()).join("has_cxx11");
 
         cc::Build::new()
-            .warnings(false)
+            .warnings(true)
+            .warnings_into_errors(true)
             .std("c++11")
             .get_compiler()
             .to_command()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,35 @@ mod glibc {
     }
 }
 
+mod cxx11 {
+    use std::{
+        env,
+        path::{Path, PathBuf},
+    };
+
+    // Attempt to compile a c program that links has the c++11 flag to determine
+    // whether it is supported.
+    pub(crate) fn has_cxx11() -> bool {
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/trivial.c");
+        println!("cargo:rerun-if-changed={}", src.display());
+
+        let dest =
+            PathBuf::from(env::var("OUT_DIR").unwrap()).join("has_cxx11");
+
+        cc::Build::new()
+            .warnings(false)
+            .std("c++11")
+            .get_compiler()
+            .to_command()
+            .arg(src)
+            .arg("-o")
+            .arg(dest)
+            .status()
+            .expect("failed to execute gcc")
+            .success()
+    }
+}
+
 /// The location of a library.
 #[derive(Debug, Clone)]
 pub struct LibLocation {
@@ -441,6 +470,16 @@ impl Build {
         if has_strlcpy {
             build.define("ZMQ_HAVE_STRLCPY", "1");
         }
+
+        // MSVC does not support c++11, since c++14 is the minimum.
+        if !target.contains("msvc") {
+            // Enable c++11 if possible to fix issue 45
+            // (https://github.com/jean-airoldie/zeromq-src-rs/issues/45).
+            if cxx11::has_cxx11() {
+                build.std("c++11");
+            }
+        }
+
         let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
         let lib_dir = out_dir.join("lib");
 

--- a/src/trivial.c
+++ b/src/trivial.c
@@ -1,0 +1,3 @@
+int main(void) {
+    return 0;
+}


### PR DESCRIPTION
This replicates current behavior in libzmq's CMakeLists.txt:

https://github.com/zeromq/libzmq/blob/c2fae81460d9d39a896da7b3f72484d23a172fa7/CMakeLists.txt#L114-L129

This should fix #45 as well as #42.