### PR TITLE
fix c++11 detection on older gcc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ mod cxx11 {
             PathBuf::from(env::var("OUT_DIR").unwrap()).join("has_cxx11");
 
         cc::Build::new()
+            .cpp(true)
             .warnings(true)
             .warnings_into_errors(true)
             .std("c++11")


### PR DESCRIPTION
On older GCC, the c++11 detection fails, as GCC refuses to compile for the C language with the `-std=c++11` flag.

The error is below:
```
  cc1: error: command line option '-std=c++11' is valid for C++/ObjC++ but not for C [-Werror]
  cc1: all warnings being treated as errors
```

This failure is interpreted as a lack of `-std=c++11` support, and eventually the build fails because of the absence of that flag.

I propose this fix: tell `cc` that we're compiling with c++ instead.  This means, in practice, that we will use `g++` rather than `gcc`.  