### PR TITLE
Use latest libsodium dep without linking issue on windows

### DIFF
--- a/testcrate/Cargo.toml
+++ b/testcrate/Cargo.toml
@@ -8,6 +8,11 @@ edition = "2018"
 libsodium = ['libsodium-sys-stable']
 
 [dependencies]
+# Windows link is broken on latest libsodium-sys-stable
+# https://github.com/jedisct1/libsodium-sys-stable/issues/20
+[target.'cfg(target_os = "windows")'.dependencies]
+libsodium-sys-stable = { version = "=1.21.4", optional = true }
+[target.'cfg(not(target_os = "windows"))'.dependencies]
 libsodium-sys-stable = { version = "1.0", optional = true }
 
 [build-dependencies]


### PR DESCRIPTION
An issue was introduced by libsodium-sys-stable starting from 1.22 where linking doesn't work on windows anymore.
See https://github.com/jedisct1/libsodium-sys-stable/issues/20.