### PR TITLE
fix(build): include wepoll on Windows when sys/epoll is not found

### DIFF
--- a/src/epoll.c
+++ b/src/epoll.c
@@ -1,0 +1,8 @@
+#include <sys/epoll.h>
+
+int main() {
+    HANDLE ephnd = epoll_create(0);
+    // TODO: remaining needed epoll methods..
+    int result = epoll_close(ephnd);
+    return 0;
+}


### PR DESCRIPTION
This "tries" to fix this: https://github.com/jean-airoldie/zeromq-src-rs/issues/49#issuecomment-3318372614
However, with no success. I will attach some logs ( maybe @jean-airoldie could help me :) )
I'm not sure if the fail is related to [ZeroMQ's CMake build variables logic...](https://github.com/zeromq/libzmq/blob/622fc6dde99ee172ebaa9c8628d85a7a1995a21d/CMakeLists.txt#L448) 

[logs_zmq.txt](https://github.com/user-attachments/files/22999448/logs_zmq.txt)

A simple test setup is the following:
```
rust-zmq/  test_crate/  zeromq-src-rs/
```

where
- `rust-zmq`: Change `zmq-sys` dependency to point at local crate: `zeromq-src = { path = "../../zeromq-src-rs"}`
- `test_crate`: Compile as `cdylib` and create an external method, e.g.:
```rs
#[unsafe(no_mangle)]
pub unsafe extern "C" fn ffi_method_zeromq() {
    let version = zmq::version();
    println!("{version:?}");
}
```
- `zeromq-src-rs`: This PR branch.